### PR TITLE
fix: 스케줄 달력에서 마지막 주 사전질문 들어가면 무한 새로고침 되는 문제 수정

### DIFF
--- a/frontend/src/views/client/ClientPreQuestionView.vue
+++ b/frontend/src/views/client/ClientPreQuestionView.vue
@@ -52,20 +52,6 @@ const canAskPreQuestion = computed(() => {
   return (start - now) > 10 * 60 * 1000;
 });
 
-// 방송 시작 10분 전 자동 새로고침
-function getMsToStart() {
-  if (!preQuestion.value.startTime) return null;
-  return new Date(preQuestion.value.startTime) - new Date();
-}
-function autoReloadWhenNeeded() {
-  const msLeft = getMsToStart();
-  if (msLeft === null) return;
-  if (msLeft <= 10 * 60 * 1000) return;
-  setTimeout(() => {
-    location.reload();
-  }, msLeft - 10 * 60 * 1000);
-}
-
 onMounted(async () => {
   const token = await getValidToken();
   if (token) {
@@ -97,13 +83,23 @@ onMounted(async () => {
 
   preQuestion.value = data;
   scrollToPreQuestionBottom();
-  autoReloadWhenNeeded();
 });
 
 const submitQuestion = async () => {
   if (!inputContent.value.trim()) {
     alert('내용을 입력해주세요!');
     return;
+  }
+  // 방송 시작 시간 검사 (등록 시점)
+  if (preQuestion.value.startTime) {
+    const start = new Date(preQuestion.value.startTime);
+    const now = new Date();
+    const diff = start - now;
+
+    if (diff <= 10 * 60 * 1000) {
+      alert('방송 시작 10분 전에는 사전질문을 등록할 수 없습니다.');
+      return;
+    }
   }
   const token = await getValidToken();
   if (!token) {
@@ -129,7 +125,6 @@ const submitQuestion = async () => {
     const preQRes = await axios.get(`/api/client/broadcasts/schedule/${scheduleNo}/preQuestion`);
     preQuestion.value = preQRes.data;
     scrollToPreQuestionBottom();
-    autoReloadWhenNeeded();
   } catch (e) {
     alert('등록에 실패했습니다.');
   }


### PR DESCRIPTION
## 작업 내용

- [ ] 스케줄 달력에서 마지막 주 사전질문 들어가면 무한 새로고침 되는 문제 수정



## PR 체크리스트

- [ ] 커밋 메시지를 컨벤션에 맞게 작성했나요?
- [ ] 로컬에서 테스트를 완료했나요?
- [ ] 작업 전에 dev를 pull 받고 작업했나요?
- [ ] push 하기 전에 dev를 작업 브랜치로 merge 받았나요?
- [ ] dev 브랜치로 PR 올리는 중인지 다시 확인했나요?
- [ ] PR 제목을 `feat: 작업내용 한줄 요약` 으로 올렸나요?